### PR TITLE
Set time and base32 -> hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ OnlyKey-init - A command line tool for setting PIN on OnlyKey (Initial Configura
 
 OnlyKey-utils - A command line tool for loading keys.
 
+OnlyKey-settime - A command line tool for setting the time on OnlyKey.
+
 PGPMessage - Provides a tool for decrypting and signing OpenPGP/GPG messages using OnlyKey.
 
 **Still in early development.**
@@ -141,6 +143,17 @@ Successfully set PIN
 [...]
 ```
 
+### Set time
+
+You can set the time on the OnlyKey using `onlykey-settime`.
+
+The time needs to be set to be able to use OTP. If the time is not set, the generated code will be NOTSET.
+
+If you are on Linux, you can use the following udev rule to run `onlykey-settime` when the OnlyKey is inserted:
+
+```
+ACTION=="add", KERNEL=="event[0-9]*", SUBSYSTEM=="input", ATTRS{name}=="Teensyduino Keyboard/RawHID", ENV{ID_VENDOR_ID}=="16c0", ENV{ID_MODEL_ID}=="04[789ABCD]?", RUN+="onlykey-settime"
+```
 
 ### CLI
 

--- a/onlykey/cli.py
+++ b/onlykey/cli.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 from __future__ import unicode_literals, print_function
 
+import base64
+import binascii
 import time
 import logging
 import os
@@ -121,7 +123,6 @@ def cli():
         key = prompt('Key: ',
                           is_password=Condition(lambda cli: hidden[0]),
                           key_bindings_registry=key_bindings_manager.registry)
-        #need base32 to hex conversion
         return key
 
     def prompt_pin():
@@ -201,6 +202,14 @@ def cli():
                 only_key.setslot(slot_id, MessageField.DELAY3, data[3])
             elif data[2] == 'type':
                  only_key.setslot(slot_id, MessageField.TFATYPE, data[3])
+            elif data[2] == 'googletotpkey':
+                totpkey = prompt_key()
+                totpkey = base64.b32decode(totpkey)
+                totpkey = binascii.hexlify(totpkey)
+                # pad with zeros for even digits
+                totpkey = totpkey.zfill(len(totpkey) + len(totpkey) % 2)
+                payload = [int(totpkey[i: i+2], 16) for i in range(0, len(totpkey), 2)]
+                only_key.setslot(slot_id, MessageField.TOTPKEY, payload)
             elif data[2] == 'totpkey':
                 totpkey = prompt_key()
                 only_key.setslot(slot_id, MessageField.TOTPKEY, totpkey)

--- a/onlykey/cli.py
+++ b/onlykey/cli.py
@@ -149,7 +149,9 @@ def cli():
         print()
         data = raw.split()
         # nexte = prompt_pass
-        if data[0] == 'getlabels':
+        if data[0] == "settime":
+            only_key.set_time(time.time())
+        elif data[0] == 'getlabels':
             tmp = {}
             for slot in only_key.getlabels():
                 tmp[slot.name] = slot

--- a/onlykey/client.py
+++ b/onlykey/client.py
@@ -184,7 +184,18 @@ class OnlyKey(object):
         return self._hid.close()
 
     def initialized(self):
-        return self._read_string() == 'INITIALIZED'
+        return self.read_string() == 'INITIALIZED'
+
+    def set_time(self, timestamp):
+        # Hex format without leading 0x
+        current_epoch_time = format(int(timestamp), 'x')
+        # pad with zeros for even digits
+        current_epoch_time = current_epoch_time.zfill(len(current_epoch_time) + len(current_epoch_time) % 2)
+        logging.debug('Setting current epoch time =', current_epoch_time)
+        payload = [int(current_epoch_time[i: i+2], 16) for i in range(0, len(current_epoch_time), 2)]
+
+        logging.debug('SENDING OKSETTIME:', [x for x in enumerate(payload)]);
+        self.send_message(msg=Message.OKSETTIME, payload=payload)
 
     def set_ecc_key(self, key_type, slot, key):
         payload = [key_type, slot] + [ord(c) for c in key]

--- a/onlykey/settime.py
+++ b/onlykey/settime.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+
+import time
+
+from client import OnlyKey
+
+def main():
+    only_key = OnlyKey()
+
+    only_key.set_time(time.time())
+    only_key.close()

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
             'onlykey-cli=onlykey.cli:main',
             'onlykey-utils=onlykey.cli:utils',
             'onlykey-init=onlykey.cli:init',
+            'onlykey-settime=onlykey.settime:main'
         ],
     },
     install_requires=['hidapi', 'aenum', 'six', 'prompt_toolkit', 'ed25519', 'cython'],


### PR DESCRIPTION
Hi

This adds support for setting the time from the cli or using the new onlykey-settime script. It also adds a new command for converting base32 to hex. I've done it as a separate command to match the web app, which only converts from base32 to hex if the OTP is set to Google.

With these two additions, I am able to successfully login to GMail without requiring the Chrome web app.