### PR TITLE
Add instructions how to get onlykey-cli running on NixOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,33 @@ $ sudo pacman -Sy git python2-setuptools python2 libusb python2-pip
 $ pip install onlykey
 ```
 
+### NixOS Install with dependencies
+
+#### First time
+
+NB: shell prompts are approximative
+
+```
+$ git clone --depth 1 https://github.com/trustcrypto/python-onlykey.git
+$ cd python-onlykey
+$ git submodule init
+$ git submodule update
+$ nix-shell -p python2.pkgs.{pip,virtualenv,ed25519,cython,six,hidapi,ecdsa,aenum,wcwidth}
+# Not prompt_toolkit, on my NixOS 18.09.2390.40e716b92a7 (Jellyfish), prompt_toolkit=1.0.15
+# but onlykey wants prompt_toolkit > 2
+[nix-shell]$ virtualenv --system-site-packages build
+[nix-shell]$ source build/bin/activate
+(build) [nix-shell]$ pip install 'prompt_toolkit>2'
+```
+
+#### After that
+
+You can run the tool with
+
+```
+$ nix-shell -p python2.pkgs.{pip,virtualenv,ed25519,cython,six,hidapi,ecdsa,aenum,wcwidth} --command 'cd python-onlykey && source build/bin/activate ; cd onlykey && python -c "import cli; cli.main()"'
+```
+
 ### FreeBSD Install with dependencies
 
 See forum thread - https://groups.google.com/forum/#!category-topic/onlykey/new-features-and-feature-requests/CEYwdXjB508


### PR DESCRIPTION
I wanted onlykey-cli to run on my NixOS system and couldn't find it in the NixOS repository.  Apparently, NixOS still contains an outdated prompt_toolkit library version, so my install instructions are a bit outlandish.  But hey, it works for me.