### PR TITLE
Change read_bytes to_str argument to to_bytes

### DIFF
--- a/onlykey/client.py
+++ b/onlykey/client.py
@@ -338,7 +338,7 @@ class OnlyKey(object):
             self.send_message(payload=current_payload, msg=msg)
         return
 
-    def read_bytes(self, n=64, to_str=False, timeout_ms=100):
+    def read_bytes(self, n=64, to_bytes=False, timeout_ms=100):
         """Read n bytes and return an array of uint8 (int)."""
         out = self._hid.read(n, timeout_ms=timeout_ms)
         logging.debug('read="%s"', ''.join([chr(c) for c in out]))
@@ -353,9 +353,9 @@ class OnlyKey(object):
         elif outstr.decode(errors="ignore").find("Timeout occured while waiting for confirmation on OnlyKey") != -1:
             raise RuntimeError('Timeout occured while waiting for confirmation on OnlyKey')
 
-        if to_str:
+        if to_bytes:
             # Returns the bytes a string if requested
-            return ''.join([bytes(c) for c in out])
+            return bytes(out)
 
         # Returns the raw list
         return out
@@ -476,7 +476,7 @@ class OnlyKey(object):
         ok_sign1 = ''
         while ok_sign1 == '':
             time.sleep(0.5)
-            ok_sign1 = self.read_bytes(64, to_str=True)
+            ok_sign1 = self.read_bytes(64, to_bytes=True)
             print(type(ok_sign1))
 
         print()
@@ -485,7 +485,7 @@ class OnlyKey(object):
 
         print('Trying to read the signature part 2...')
         for _ in range(10):
-            ok_sign2 = self.read_bytes(64, to_str=True)
+            ok_sign2 = self.read_bytes(64, to_bytes=True)
             if len(ok_sign2) == 64:
                 break
 
@@ -495,7 +495,7 @@ class OnlyKey(object):
 
         print('Trying to read the signature part 3...')
         for _ in range(10):
-            ok_sign3 = self.read_bytes(64, to_str=True)
+            ok_sign3 = self.read_bytes(64, to_bytes=True)
             if len(ok_sign3) == 64:
                 break
 
@@ -506,7 +506,7 @@ class OnlyKey(object):
 
         print('Trying to read the signature part 4...')
         for _ in range(10):
-            ok_sign4 = self.read_bytes(64, to_str=True)
+            ok_sign4 = self.read_bytes(64, to_bytes=True)
             if len(ok_sign4) == 64:
                 break
 
@@ -517,7 +517,7 @@ class OnlyKey(object):
 
         print('Trying to read the signature part 5...')
         for _ in range(10):
-            ok_sign5 = self.read_bytes(64, to_str=True)
+            ok_sign5 = self.read_bytes(64, to_bytes=True)
             if len(ok_sign5) == 64:
                 break
 
@@ -528,7 +528,7 @@ class OnlyKey(object):
 
         print('Trying to read the signature part 6...')
         for _ in range(10):
-            ok_sign6 = self.read_bytes(64, to_str=True)
+            ok_sign6 = self.read_bytes(64, to_bytes=True)
             if len(ok_sign6) == 64:
                 break
 
@@ -539,7 +539,7 @@ class OnlyKey(object):
 
         print('Trying to read the signature part 7...')
         for _ in range(10):
-            ok_sign7 = self.read_bytes(64, to_str=True)
+            ok_sign7 = self.read_bytes(64, to_bytes=True)
             if len(ok_sign7) == 64:
                 break
 
@@ -550,7 +550,7 @@ class OnlyKey(object):
 
         print('Trying to read the signature part 8...')
         for _ in range(10):
-            ok_sign8 = self.read_bytes(64, to_str=True)
+            ok_sign8 = self.read_bytes(64, to_bytes=True)
             if len(ok_sign8) == 64:
                 break
 
@@ -593,7 +593,7 @@ class OnlyKey(object):
         ok_pubkey1 = ''
         while ok_pubkey1 == '':
             time.sleep(0.5)
-            ok_pubkey1 = self.read_bytes(64, to_str=True)
+            ok_pubkey1 = self.read_bytes(64, to_bytes=True)
 
         print()
 
@@ -601,7 +601,7 @@ class OnlyKey(object):
 
         print('Trying to read the public RSA N part 2...')
         for _ in range(10):
-            ok_pubkey2 = self.read_bytes(64, to_str=True)
+            ok_pubkey2 = self.read_bytes(64, to_bytes=True)
             if len(ok_pubkey2) == 64:
                 break
 
@@ -611,7 +611,7 @@ class OnlyKey(object):
 
         print('Trying to read the public RSA N part 3...')
         for _ in range(10):
-            ok_pubkey3 = self.read_bytes(64, to_str=True)
+            ok_pubkey3 = self.read_bytes(64, to_bytes=True)
             if len(ok_pubkey3) == 64:
                 break
 
@@ -622,7 +622,7 @@ class OnlyKey(object):
 
         print('Trying to read the public RSA N part 4...')
         for _ in range(10):
-            ok_pubkey4 = self.read_bytes(64, to_str=True)
+            ok_pubkey4 = self.read_bytes(64, to_bytes=True)
             if len(ok_pubkey4) == 64:
                 break
 
@@ -633,7 +633,7 @@ class OnlyKey(object):
 
         print('Trying to read the public RSA N part 5...')
         for _ in range(10):
-            ok_pubkey5 = self.read_bytes(64, to_str=True)
+            ok_pubkey5 = self.read_bytes(64, to_bytes=True)
             if len(ok_pubkey5) == 64:
                 break
 
@@ -644,7 +644,7 @@ class OnlyKey(object):
 
         print('Trying to read the public RSA N part 6...')
         for _ in range(10):
-            ok_pubkey6 = self.read_bytes(64, to_str=True)
+            ok_pubkey6 = self.read_bytes(64, to_bytes=True)
             if len(ok_pubkey6) == 64:
                 break
 
@@ -654,7 +654,7 @@ class OnlyKey(object):
 
         print('Trying to read the public RSA N part 7...')
         for _ in range(10):
-            ok_pubkey7 = self.read_bytes(64, to_str=True)
+            ok_pubkey7 = self.read_bytes(64, to_bytes=True)
             if len(ok_pubkey7) == 64:
                 break
 
@@ -664,7 +664,7 @@ class OnlyKey(object):
         print('Trying to read the public RSA N part 8...')
 
         for _ in range(10):
-            ok_pubkey8 = self.read_bytes(64, to_str=True)
+            ok_pubkey8 = self.read_bytes(64, to_bytes=True)
             if len(ok_pubkey8) == 64:
                 break
 
@@ -724,7 +724,7 @@ class OnlyKey(object):
         ok_decrypted = ''
         while ok_decrypted == '':
             time.sleep(0.5)
-            ok_decrypted = self.read_bytes(64, to_str=True)
+            ok_decrypted = self.read_bytes(64, to_bytes=True)
 
         print('Decrypted by OnlyKey, data=', repr(ok_decrypted))
 
@@ -741,7 +741,7 @@ class OnlyKey(object):
 
         log.info('Trying to read the private key...')
         for _ in range(2):
-            ok_priv = self.read_bytes(64, to_str=True, timeout_ms=10)
+            ok_priv = self.read_bytes(64, to_bytes=True, timeout_ms=10)
             if len(ok_priv) == 64:
                 break
 

--- a/tests/ecdh_curve25519.py
+++ b/tests/ecdh_curve25519.py
@@ -159,7 +159,7 @@ print('Trying to read the shared secret from OnlyKey...')
 ok_shared_secret = ''
 while ok_shared_secret == '':
     time.sleep(0.5)
-    ok_shared_secret = ok.read_bytes(64, to_str=True)
+    ok_shared_secret = ok.read_bytes(64, to_bytes=True)
 
 print('OnlyKey Shared Secret =', repr(ok_shared_secret))
 
@@ -174,7 +174,7 @@ print()
 #ok_KEK = ''
 #while ok_KEK == '':
 #    time.sleep(0.5)
-#    ok_KEK = ok.read_bytes(len(KEK), to_str=True)
+#    ok_KEK = ok.read_bytes(len(KEK), to_bytes=True)
 
 #print 'OnlyKey KEK =', repr(ok_KEK)
 

--- a/tests/ecdh_p256.py
+++ b/tests/ecdh_p256.py
@@ -150,7 +150,7 @@ print('Trying to read the shared secret from OnlyKey...')
 ok_shared_secret = ''
 while ok_shared_secret == '':
     time.sleep(0.5)
-    ok_shared_secret = ok.read_bytes(len(shared_secret1), to_str=True)
+    ok_shared_secret = ok.read_bytes(len(shared_secret1), to_bytes=True)
 
 print('OnlyKey Shared Secret =', hexlify(ok_shared_secret))
 

--- a/tests/ecdh_secp256k1.py
+++ b/tests/ecdh_secp256k1.py
@@ -150,7 +150,7 @@ print('Trying to read the shared secret from OnlyKey...')
 ok_shared_secret = ''
 while ok_shared_secret == '':
     time.sleep(0.5)
-    ok_shared_secret = ok.read_bytes(len(shared_secret1), to_str=True)
+    ok_shared_secret = ok.read_bytes(len(shared_secret1), to_bytes=True)
 
 print('OnlyKey Shared Secret =', hexlify(ok_shared_secret))
 

--- a/tests/rsa_decrypt_1024.py
+++ b/tests/rsa_decrypt_1024.py
@@ -158,7 +158,7 @@ print('Trying to read the decrypted data from OnlyKey...')
 ok_decrypted = ''
 while ok_decrypted == '':
     time.sleep(0.5)
-    ok_decrypted = ok.read_bytes(len(message), to_str=True)
+    ok_decrypted = ok.read_bytes(len(message), to_bytes=True)
 
 dsize = len(message)
 sentinel = Random.new().read(15+dsize)

--- a/tests/rsa_decrypt_2048.py
+++ b/tests/rsa_decrypt_2048.py
@@ -93,7 +93,7 @@ print('Trying to read the public RSA N part 1...')
 ok.send_message(msg=Message.OKGETPUBKEY, payload=chr(1))  #, payload=[1, 1])
 time.sleep(1.5)
 for _ in xrange(10):
-    ok_pubkey1 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey1 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey1) == 64:
         break
     time.sleep(1)
@@ -104,7 +104,7 @@ print('received=', repr(ok_pubkey1))
 
 print('Trying to read the public RSA N part 2...')
 for _ in xrange(10):
-    ok_pubkey2 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey2 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey2) == 64:
         break
     time.sleep(1)
@@ -115,7 +115,7 @@ print('received=', repr(ok_pubkey2))
 
 print('Trying to read the public RSA N part 3...')
 for _ in xrange(10):
-    ok_pubkey3 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey3 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey3) == 64:
         break
     time.sleep(1)
@@ -126,7 +126,7 @@ print('received=', repr(ok_pubkey3))
 
 print('Trying to read the public RSA N part 4...')
 for _ in xrange(10):
-    ok_pubkey4 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey4 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey4) == 64:
         break
     time.sleep(1)
@@ -180,7 +180,7 @@ print('Trying to read the decrypted data from OnlyKey...')
 ok_decrypted = ''
 while ok_decrypted == '':
     time.sleep(0.5)
-    ok_decrypted = ok.read_bytes(len(message), to_str=True)
+    ok_decrypted = ok.read_bytes(len(message), to_bytes=True)
 
 dsize = len(message)
 sentinel = Random.new().read(15+dsize)

--- a/tests/rsa_decrypt_3072.py
+++ b/tests/rsa_decrypt_3072.py
@@ -93,7 +93,7 @@ print('Trying to read the public RSA N part 1...')
 ok.send_message(msg=Message.OKGETPUBKEY, payload=chr(1))  #, payload=[1, 1])
 time.sleep(1.5)
 for _ in xrange(10):
-    ok_pubkey1 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey1 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey1) == 64:
         break
     time.sleep(1)
@@ -104,7 +104,7 @@ print('received=', repr(ok_pubkey1))
 
 print('Trying to read the public RSA N part 2...')
 for _ in xrange(10):
-    ok_pubkey2 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey2 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey2) == 64:
         break
     time.sleep(1)
@@ -115,7 +115,7 @@ print('received=', repr(ok_pubkey2))
 
 print('Trying to read the public RSA N part 3...')
 for _ in xrange(10):
-    ok_pubkey3 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey3 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey3) == 64:
         break
     time.sleep(1)
@@ -126,7 +126,7 @@ print('received=', repr(ok_pubkey3))
 
 print('Trying to read the public RSA N part 4...')
 for _ in xrange(10):
-    ok_pubkey4 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey4 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey4) == 64:
         break
     time.sleep(1)
@@ -137,7 +137,7 @@ print('received=', repr(ok_pubkey4))
 
 print('Trying to read the public RSA N part 5...')
 for _ in xrange(10):
-    ok_pubkey5 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey5 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey5) == 64:
         break
     time.sleep(1)
@@ -148,7 +148,7 @@ print('received=', repr(ok_pubkey5))
 
 print('Trying to read the public RSA N part 6...')
 for _ in xrange(10):
-    ok_pubkey6 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey6 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey6) == 64:
         break
     time.sleep(1)
@@ -202,7 +202,7 @@ print('Trying to read the decrypted data from OnlyKey...')
 ok_decrypted = ''
 while ok_decrypted == '':
     time.sleep(0.5)
-    ok_decrypted = ok.read_bytes(len(message), to_str=True)
+    ok_decrypted = ok.read_bytes(len(message), to_bytes=True)
 
 dsize = len(message)
 sentinel = Random.new().read(15+dsize)

--- a/tests/rsa_decrypt_4096.py
+++ b/tests/rsa_decrypt_4096.py
@@ -93,7 +93,7 @@ print('Trying to read the public RSA N part 1...')
 ok.send_message(msg=Message.OKGETPUBKEY, payload=chr(1))  #, payload=[1, 1])
 time.sleep(1.5)
 for _ in xrange(10):
-    ok_pubkey1 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey1 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey1) == 64:
         break
     time.sleep(1)
@@ -104,7 +104,7 @@ print('received=', repr(ok_pubkey1))
 
 print('Trying to read the public RSA N part 2...')
 for _ in xrange(10):
-    ok_pubkey2 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey2 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey2) == 64:
         break
     time.sleep(1)
@@ -115,7 +115,7 @@ print('received=', repr(ok_pubkey2))
 
 print('Trying to read the public RSA N part 3...')
 for _ in xrange(10):
-    ok_pubkey3 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey3 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey3) == 64:
         break
     time.sleep(1)
@@ -126,7 +126,7 @@ print('received=', repr(ok_pubkey3))
 
 print('Trying to read the public RSA N part 4...')
 for _ in xrange(10):
-    ok_pubkey4 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey4 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey4) == 64:
         break
     time.sleep(1)
@@ -137,7 +137,7 @@ print('received=', repr(ok_pubkey4))
 
 print('Trying to read the public RSA N part 5...')
 for _ in xrange(10):
-    ok_pubkey5 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey5 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey5) == 64:
         break
     time.sleep(1)
@@ -148,7 +148,7 @@ print('received=', repr(ok_pubkey5))
 
 print('Trying to read the public RSA N part 6...')
 for _ in xrange(10):
-    ok_pubkey6 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey6 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey6) == 64:
         break
     time.sleep(1)
@@ -159,7 +159,7 @@ print('received=', repr(ok_pubkey6))
 
 print('Trying to read the public RSA N part 7...')
 for _ in xrange(10):
-    ok_pubkey7 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey7 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey7) == 64:
         break
     time.sleep(1)
@@ -170,7 +170,7 @@ print('received=', repr(ok_pubkey7))
 
 print('Trying to read the public RSA N part 8...')
 for _ in xrange(10):
-    ok_pubkey8 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey8 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey8) == 64:
         break
     time.sleep(1)
@@ -224,7 +224,7 @@ print('Trying to read the decrypted data from OnlyKey...')
 ok_decrypted = ''
 while ok_decrypted == '':
     time.sleep(0.5)
-    ok_decrypted = ok.read_bytes(len(message), to_str=True)
+    ok_decrypted = ok.read_bytes(len(message), to_bytes=True)
 
 dsize = len(message)
 sentinel = Random.new().read(15+dsize)

--- a/tests/rsa_decrypt_testkey.py
+++ b/tests/rsa_decrypt_testkey.py
@@ -37,7 +37,7 @@ print('Trying to read the public RSA N part 1...')
 ok.send_message(msg=Message.OKGETPUBKEY, payload=chr(slot))  #, payload=[1, 1])
 time.sleep(1.5)
 for _ in xrange(10):
-    ok_pubkey1 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey1 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey1) == 64:
         break
     time.sleep(1)
@@ -48,7 +48,7 @@ print('received=', repr(ok_pubkey1))
 
 print('Trying to read the public RSA N part 2...')
 for _ in xrange(10):
-    ok_pubkey2 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey2 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey2) == 64:
         break
     time.sleep(1)
@@ -59,7 +59,7 @@ print('received=', repr(ok_pubkey2))
 
 print('Trying to read the public RSA N part 3...')
 for _ in xrange(10):
-    ok_pubkey3 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey3 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey3) == 64:
         break
     time.sleep(1)
@@ -70,7 +70,7 @@ print('received=', repr(ok_pubkey3))
 
 print('Trying to read the public RSA N part 4...')
 for _ in xrange(10):
-    ok_pubkey4 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey4 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey4) == 64:
         break
     time.sleep(1)
@@ -81,7 +81,7 @@ print('received=', repr(ok_pubkey4))
 
 print('Trying to read the public RSA N part 5...')
 for _ in xrange(10):
-    ok_pubkey5 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey5 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey5) == 64:
         break
     time.sleep(1)
@@ -92,7 +92,7 @@ print('received=', repr(ok_pubkey5))
 
 print('Trying to read the public RSA N part 6...')
 for _ in xrange(10):
-    ok_pubkey6 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey6 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey6) == 64:
         break
     time.sleep(1)
@@ -103,7 +103,7 @@ print('received=', repr(ok_pubkey6))
 
 print('Trying to read the public RSA N part 7...')
 for _ in xrange(10):
-    ok_pubkey7 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey7 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey7) == 64:
         break
     time.sleep(1)
@@ -114,7 +114,7 @@ print('received=', repr(ok_pubkey7))
 
 print('Trying to read the public RSA N part 8...')
 for _ in xrange(10):
-    ok_pubkey8 = ok.read_bytes(64, to_str=True, timeout_ms=1000)
+    ok_pubkey8 = ok.read_bytes(64, to_bytes=True, timeout_ms=1000)
     if len(ok_pubkey8) == 64:
         break
     time.sleep(1)
@@ -180,7 +180,7 @@ print('Trying to read the decrypted data from OnlyKey...')
 ok_decrypted = ''
 while ok_decrypted == '':
     time.sleep(0.5)
-    ok_decrypted = ok.read_bytes(len(message), to_str=True)
+    ok_decrypted = ok.read_bytes(len(message), to_bytes=True)
 
 print('Decrypted by OnlyKey, data=', repr(ok_decrypted))
 

--- a/tests/ssh_auth_ed25519.py
+++ b/tests/ssh_auth_ed25519.py
@@ -49,7 +49,7 @@ ok.send_message(msg=Message.OKGETPUBKEY, payload=101, slot_id=65)  #, payload=[1
 time.sleep(1.5)
 for i in range(10):
     print(i)
-    ok_pubkey = ok.read_bytes(32, to_str=True)
+    ok_pubkey = ok.read_bytes(32, to_bytes=True)
     print(ok_pubkey)
     if len(ok_pubkey) == 32:
         break
@@ -122,7 +122,7 @@ input()
 signature = ''
 while signature == '':
     time.sleep(0.5)
-    signature = ok.read_bytes(64, to_str=True)
+    signature = ok.read_bytes(64, to_bytes=True)
 
 print('Signed by OnlyKey, signature=', repr(signature))
 

--- a/tests/ssh_auth_rsa_1024.py
+++ b/tests/ssh_auth_rsa_1024.py
@@ -95,7 +95,7 @@ print('Trying to read the public RSA N part 1...')
 ok.send_message(msg=Message.OKGETPUBKEY, payload=chr(1))  #, payload=[1, 1])
 time.sleep(1.5)
 for _ in xrange(10):
-    ok_pubkey1 = ok.read_bytes(64, to_str=True)
+    ok_pubkey1 = ok.read_bytes(64, to_bytes=True)
     if len(ok_pubkey1) == 64:
         break
     time.sleep(1)
@@ -106,7 +106,7 @@ print('received=', repr(ok_pubkey1))
 
 print('Trying to read the public RSA N part 2...')
 for _ in xrange(10):
-    ok_pubkey2 = ok.read_bytes(64, to_str=True)
+    ok_pubkey2 = ok.read_bytes(64, to_bytes=True)
     if len(ok_pubkey2) == 64:
         break
     time.sleep(1)
@@ -157,7 +157,7 @@ print('Trying to read the signature part 1...')
 signature1 = ''
 while signature1 == '':
     time.sleep(0.5)
-    signature1 = ok.read_bytes(64, to_str=True)
+    signature1 = ok.read_bytes(64, to_bytes=True)
 
 print('received=', repr(signature1))
 
@@ -165,7 +165,7 @@ print('Trying to read the signature part 2...')
 signature2 = ''
 while signature2 == '':
     time.sleep(0.5)
-    signature2 = ok.read_bytes(64, to_str=True)
+    signature2 = ok.read_bytes(64, to_bytes=True)
 
 print('received=', repr(signature2))
 


### PR DESCRIPTION
`read_bytes` was broken when using Python 3 when setting `to_str` to True.
For example when called from *onlykey-agent*:

```
Traceback (most recent call last):
  File "/home/fidel/Code/virtualenvs/onlykey-agent/bin/onlykey-agent", line 11, in <module>
    load_entry_point('onlykey-agent', 'console_scripts', 'onlykey-agent')()
  File "/home/fidel/Code/onlykey-agent/onlykey_agent/__main__.py", line 125, in wrapper
    return func(*args, **kwargs)
  File "/home/fidel/Code/onlykey-agent/onlykey_agent/__main__.py", line 142, in run_agent
    public_key = conn.get_public_key(label=label)
  File "/home/fidel/Code/onlykey-agent/onlykey_agent/client.py", line 71, in get_public_key
    ok_pubkey = self.ok.read_bytes(64, to_str=True, timeout_ms=10)
  File "/home/fidel/Code/onlykey-python/onlykey/client.py", line 358, in read_bytes
    return ''.join([bytes(c) for c in out])
TypeError: sequence item 0: expected str instance, bytes found
```