### PR TITLE
Fix unsafe install instructions for ArchLinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ sudo udevadm control --reload-rules && udevadm trigger
 
 #### Arch Linux Install with dependencies
 ```
-$ sudo pacman -Sy git python3-setuptools python3 libusb python3-pip
+$ sudo pacman -Syu git python3-setuptools python3 libusb python3-pip
 $ pip3 install onlykey
 $ wget https://raw.githubusercontent.com/trustcrypto/trustcrypto.github.io/master/49-onlykey.rules
 $ sudo cp 49-onlykey.rules /etc/udev/rules.d/


### PR DESCRIPTION
`pacman -Sy <packagename>` puts the user in a partial upgrade state, which is not supported, and can cause unrelated breakage. Perform full system update along with package installation with `pacman -Syu <packagename>`

Ref: https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported
Further Discussion: https://gist.github.com/vodik/5660494