### PR TITLE
Proper system exit when device not found

### DIFF
--- a/onlykey/cli.py
+++ b/onlykey/cli.py
@@ -27,7 +27,13 @@ import nacl.signing
 
 from .client import OnlyKey, Message, MessageField
 
-only_key = OnlyKey()
+# set 0 to disable Traceback output on exceptions
+sys.tracebacklimit = 1
+
+try: 
+    only_key = OnlyKey()
+except:
+    raise SystemExit
 
 def cli():
 

--- a/onlykey/client.py
+++ b/onlykey/client.py
@@ -269,11 +269,15 @@ class OnlyKey(object):
                             self._hid = hid.device()
                             self._hid.open_path(self.path)
                             self._hid.set_nonblocking(True)
+                            return
                     else:
+                        # FIDO Alliance Page
                         if usage_page == 0xf1d0 or interface_number == 1:
                             self._hid = hid.device()
                             self._hid.open_path(self.path)
                             self._hid.set_nonblocking(True)
+                            return
+            raise OnlyKeyUnavailableException('device not found')
 
         except:
             log.exception('failed to connect')


### PR DESCRIPTION
When device (OnlyKey) is not available the `onlykey-cli` still starts in interactive mode, and on usage or exit it throws exception error.
This is a simple solution to catch the absence of onlykey device and exit immediately if device can't be found.

PS: Also added variable to disable traceback output on exceptions, but set to print out traceback by default.