### PR TITLE
fix to set HMAC

### DIFF
--- a/onlykey/cli.py
+++ b/onlykey/cli.py
@@ -413,7 +413,11 @@ def cli():
                         slot_id = slot_id + 24
                     only_key.setslot(slot_id, MessageField.LABEL, sys.argv[4])
                 else:
-                    only_key.setkey(slot_id, sys.argv[3], sys.argv[4], sys.argv[5])
+                    # for HMAC we don't need key_feature
+                    if sys.argv[3] == 'h':
+                        only_key.setkey(slot_id, sys.argv[3], key_features=None, value=sys.argv[4])
+                    else:
+                        only_key.setkey(slot_id, sys.argv[3], key_features=sys.argv[4], value=sys.argv[5])
             except:
                 print(sys.exc_info()[0])
                 print('Input error. See available commands with examples here https://docs.crp.to/command-line.html')
@@ -947,7 +951,11 @@ def cli():
                         only_key.setslot(slot_id, MessageField.LABEL, data[3])
                     else:
                         key = prompt_pass()
-                        only_key.setkey(slot_id, data[2], data[3], key)
+                        # for HMAC we don't need key_feature
+                        if data[2] == 'h':
+                             only_key.setkey(slot_id, data[2], key_features=None, value=key)
+                        else:
+                            only_key.setkey(slot_id, data[2], key_features=data[3], value=key)
                 except:
                     print(sys.exc_info()[0])
                     print('Input error. See available commands with examples here https://docs.crp.to/command-line.html')

--- a/onlykey/client.py
+++ b/onlykey/client.py
@@ -519,7 +519,7 @@ class OnlyKey(object):
         for _ in range(8):
             print(self.read_string())
 
-    def setkey(self, slot_number, key_type, key_features, value):
+    def setkey(self, slot_number, key_type, value, key_features=None):
         # slot 131-132 Reserved
         # slot 129-130 HMAC Keys
         # slot 101-116 ECC Keys
@@ -564,7 +564,11 @@ class OnlyKey(object):
                 self.send_message(msg=Message.OKSETPRIV, slot_id=slot_number, payload=format(key_type, 'x')+value[798:912])
                 self.send_message(msg=Message.OKSETPRIV, slot_id=slot_number, payload=format(key_type, 'x')+value[912:1024])
         else:
-            self.send_message(msg=Message.OKSETPRIV, slot_id=slot_number, payload=format(key_type, 'x')+value)
+            # the key_type format must be 2 char output, the byte check later will fail
+            if key_type == 9:
+                self.send_message(msg=Message.OKSETPRIV, slot_id=slot_number, payload=format(key_type, '02x')+value)
+            else:
+                self.send_message(msg=Message.OKSETPRIV, slot_id=slot_number, payload=format(key_type, 'x')+value)
         time.sleep(1)
         print(self.read_string())
 


### PR DESCRIPTION
This will fix setting the private key HMAC;
While setting HMAC we don't need the key_feature.
However the setkey function in client.py was expecting a key_feature.

This was the quickest fix, but probably not the most elegant. Further code cleanup might be required and might follow.

PS: I just tested the use case for setting HMAC, proper testing for other priv key types should be done.