### PR TITLE
Enable to set and wipe the backup passphrase key

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ One of the buttons on OnlyKey can be configured as a lock button.
 
 #### setkey [key slot] [type] [features] [hex key]
 Sets raw private keys and key labels, to set PEM format keys use the OnlyKey App
-  - [key slot] must be key number RSA1 - RSA4, ECC1 - ECC16, HMAC1 - HMAC2
+  - [key slot] must be key number RSA1 - RSA4, ECC1 - ECC16, HMAC1 - HMAC2, BACKUP
   - [type] must be one of the following:
     - label - set to have a descriptive key label i.e. My GPG signing key
     - x - X25519 Key Type (32 bytes)
@@ -280,7 +280,7 @@ Generates random private key on device
 
 #### wipekey [key id]
 Erases key stored at [key id]
-  - [key id] must be key number RSA1 - RSA4, ECC1 - ECC16, HMAC1 - HMAC2
+  - [key id] must be key number RSA1 - RSA4, ECC1 - ECC16, HMAC1 - HMAC2, BACKUP
 
 ### FIDO2 Config Options
 

--- a/onlykey/cli.py
+++ b/onlykey/cli.py
@@ -114,7 +114,7 @@ def cli():
                 print(only_key.read_string())
                 print ()
         elif sys.argv[1] == 'getlabels':
-            tmp = {}      
+            tmp = {}
             only_key.set_time(time.time())
             okversion = only_key.read_string()
             if okversion[19] == 'c':
@@ -251,7 +251,7 @@ def cli():
             elif sys.argv[3] == 'delay3':
                 only_key.setslot(slot_id, MessageField.DELAY3, sys.argv[4])
             elif sys.argv[3] == '2fa':
-                 only_key.setslot(slot_id, MessageField.TFATYPE, sys.argv[4])
+                only_key.setslot(slot_id, MessageField.TFATYPE, sys.argv[4])
             elif sys.argv[3] == 'gkey':
                 totpkey = prompt_key()
                 totpkey = base64.b32decode("".join(totpkey.split()).upper())
@@ -470,31 +470,31 @@ def cli():
                 return
             only_key.wipekey(slot_id)
         elif sys.argv[1] == 'idletimeout':
-             only_key.setslot(1, MessageField.IDLETIMEOUT, int(sys.argv[2]))
+            only_key.setslot(1, MessageField.IDLETIMEOUT, int(sys.argv[2]))
         elif sys.argv[1] == 'wipemode':
-             only_key.setslot(1, MessageField.WIPEMODE, int(sys.argv[2]))
+            only_key.setslot(1, MessageField.WIPEMODE, int(sys.argv[2]))
         elif sys.argv[1] == 'keytypespeed':
-             only_key.setslot(99, MessageField.KEYTYPESPEED, int(sys.argv[2]))
+            only_key.setslot(99, MessageField.KEYTYPESPEED, int(sys.argv[2]))
         elif sys.argv[1] == 'ledbrightness':
-             only_key.setslot(1, MessageField.LEDBRIGHTNESS, int(sys.argv[2]))
+            only_key.setslot(1, MessageField.LEDBRIGHTNESS, int(sys.argv[2]))
         elif sys.argv[1] == 'touchsense':
             only_key.setslot(1, MessageField.TOUCHSENSE, int(sys.argv[2]))
         elif sys.argv[1] == '2ndprofilemode':
-             only_key.setslot(1, MessageField.SECPROFILEMODE, int(sys.argv[2]))
+            only_key.setslot(1, MessageField.SECPROFILEMODE, int(sys.argv[2]))
         elif sys.argv[1] == 'storedkeymode':
-             only_key.setslot(1, MessageField.PGPCHALENGEMODE, int(sys.argv[2]))
+            only_key.setslot(1, MessageField.PGPCHALENGEMODE, int(sys.argv[2]))
         elif sys.argv[1] == 'derivedkeymode':
-             only_key.setslot(1, MessageField.SSHCHALENGEMODE, int(sys.argv[2]))
+            only_key.setslot(1, MessageField.SSHCHALENGEMODE, int(sys.argv[2]))
         elif sys.argv[1] == 'backupkeymode':
-             only_key.setslot(1, MessageField.BACKUPMODE, int(sys.argv[2]))
+            only_key.setslot(1, MessageField.BACKUPMODE, int(sys.argv[2]))
         elif sys.argv[1] == 'keylayout':
-             only_key.setslot(1, MessageField.KEYLAYOUT, int(sys.argv[2]))
+            only_key.setslot(1, MessageField.KEYLAYOUT, int(sys.argv[2]))
         elif sys.argv[1] == 'sysadminmode':
-             only_key.setslot(1, MessageField.SYSADMINMODE, int(sys.argv[2]))
+            only_key.setslot(1, MessageField.SYSADMINMODE, int(sys.argv[2]))
         elif sys.argv[1] == 'lockbutton':
-             only_key.setslot(1, MessageField.LOCKBUTTON, int(sys.argv[2]))
+            only_key.setslot(1, MessageField.LOCKBUTTON, int(sys.argv[2]))
         elif sys.argv[1] == 'hmackeymode':
-             only_key.setslot(1, MessageField.HMACMODE, int(sys.argv[2]))
+            only_key.setslot(1, MessageField.HMACMODE, int(sys.argv[2]))
         elif sys.argv[1] == 'version':
             print('OnlyKey CLI v1.2.10')
         elif sys.argv[1] == 'fwversion':
@@ -644,7 +644,7 @@ def cli():
                     print(only_key.read_string())
                     print()
             elif data[0] == 'getlabels':
-                tmp = {}      
+                tmp = {}
                 only_key.set_time(time.time())
                 okversion = only_key.read_string()
                 if okversion[19] == 'c':
@@ -780,7 +780,7 @@ def cli():
                 elif data[2] == 'delay3':
                     only_key.setslot(slot_id, MessageField.DELAY3, data[3])
                 elif data[2] == '2fa':
-                     only_key.setslot(slot_id, MessageField.TFATYPE, data[3])
+                    only_key.setslot(slot_id, MessageField.TFATYPE, data[3])
                 elif data[2] == 'gkey':
                     totpkey = prompt_key()
                     totpkey = base64.b32decode("".join(totpkey.split()).upper())

--- a/onlykey/cli.py
+++ b/onlykey/cli.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals, print_function
 from __future__ import absolute_import
 
+from typing import Union
 from builtins import input
 from builtins import next
 from builtins import range
@@ -28,6 +29,34 @@ import nacl.signing
 from .client import OnlyKey, Message, MessageField
 
 only_key = OnlyKey()
+
+
+def get_slot_id (slot_name: str) -> Union[int | None]:
+    if   slot_name == 'RSA1':   return 1
+    elif slot_name == 'RSA2':   return 2
+    elif slot_name == 'RSA3':   return 3
+    elif slot_name == 'RSA4':   return 4
+    elif slot_name == 'ECC1':   return 101
+    elif slot_name == 'ECC2':   return 102
+    elif slot_name == 'ECC3':   return 103
+    elif slot_name == 'ECC4':   return 104
+    elif slot_name == 'ECC5':   return 105
+    elif slot_name == 'ECC6':   return 106
+    elif slot_name == 'ECC7':   return 107
+    elif slot_name == 'ECC8':   return 108
+    elif slot_name == 'ECC9':   return 109
+    elif slot_name == 'ECC10':  return 110
+    elif slot_name == 'ECC11':  return 111
+    elif slot_name == 'ECC12':  return 112
+    elif slot_name == 'ECC13':  return 113
+    elif slot_name == 'ECC14':  return 114
+    elif slot_name == 'ECC15':  return 115
+    elif slot_name == 'ECC16':  return 116
+    elif slot_name == 'HMAC1':  return 130
+    elif slot_name == 'HMAC2':  return 129
+    elif slot_name == 'BACKUP': return 131
+    else:                       return None
+
 
 def cli():
 
@@ -356,51 +385,7 @@ def cli():
             only_key.wipeslot(slot_id)
         elif sys.argv[1] == 'setkey' or sys.argv[1] == 'genkey':
             try:
-                slot_id = 0
-                if sys.argv[2] == 'RSA1':
-                    slot_id = 1
-                elif sys.argv[2] == 'RSA2':
-                    slot_id = 2
-                elif sys.argv[2] == 'RSA3':
-                    slot_id = 3
-                elif sys.argv[2] == 'RSA4':
-                    slot_id = 4
-                elif sys.argv[2] == 'ECC1':
-                    slot_id = 101
-                elif sys.argv[2] == 'ECC2':
-                    slot_id = 102
-                elif sys.argv[2] == 'ECC3':
-                    slot_id = 103
-                elif sys.argv[2] == 'ECC4':
-                    slot_id = 104
-                elif sys.argv[2] == 'ECC5':
-                    slot_id = 105
-                elif sys.argv[2] == 'ECC6':
-                    slot_id = 106
-                elif sys.argv[2] == 'ECC7':
-                    slot_id = 107
-                elif sys.argv[2] == 'ECC8':
-                    slot_id = 108
-                elif sys.argv[2] == 'ECC9':
-                    slot_id = 109
-                elif sys.argv[2] == 'ECC10':
-                    slot_id = 110
-                elif sys.argv[2] == 'ECC11':
-                    slot_id = 111
-                elif sys.argv[2] == 'ECC12':
-                    slot_id = 112
-                elif sys.argv[2] == 'ECC13':
-                    slot_id = 113
-                elif sys.argv[2] == 'ECC14':
-                    slot_id = 114
-                elif sys.argv[2] == 'ECC15':
-                    slot_id = 115
-                elif sys.argv[2] == 'ECC16':
-                    slot_id = 116
-                elif sys.argv[2] == 'HMAC1':
-                    slot_id = 130
-                elif sys.argv[2] == 'HMAC2':
-                    slot_id = 129
+                slot_id = get_slot_id (sys.argv[2])
                 if (sys.argv[1]=='genkey'):
                     if (slot_id > 100 and (sys.argv[3] == 'x' or sys.argv[3] == 'n' or sys.argv[3] == 's')):
                         only_key.setkey(slot_id, sys.argv[3], sys.argv[4], 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
@@ -420,50 +405,7 @@ def cli():
                 return
         elif sys.argv[1] == 'wipekey':
             try:
-                if sys.argv[2] == 'RSA1':
-                    slot_id = 1
-                elif sys.argv[2] == 'RSA2':
-                    slot_id = 2
-                elif sys.argv[2] == 'RSA3':
-                    slot_id = 3
-                elif sys.argv[2] == 'RSA4':
-                    slot_id = 4
-                elif sys.argv[2] == 'ECC1':
-                    slot_id = 101
-                elif sys.argv[2] == 'ECC2':
-                    slot_id = 102
-                elif sys.argv[2] == 'ECC3':
-                    slot_id = 103
-                elif sys.argv[2] == 'ECC4':
-                    slot_id = 104
-                elif sys.argv[2] == 'ECC5':
-                    slot_id = 105
-                elif sys.argv[2] == 'ECC6':
-                    slot_id = 106
-                elif sys.argv[2] == 'ECC7':
-                    slot_id = 107
-                elif sys.argv[2] == 'ECC8':
-                    slot_id = 108
-                elif sys.argv[2] == 'ECC9':
-                    slot_id = 109
-                elif sys.argv[2] == 'ECC10':
-                    slot_id = 110
-                elif sys.argv[2] == 'ECC11':
-                    slot_id = 111
-                elif sys.argv[2] == 'ECC12':
-                    slot_id = 112
-                elif sys.argv[2] == 'ECC13':
-                    slot_id = 113
-                elif sys.argv[2] == 'ECC14':
-                    slot_id = 114
-                elif sys.argv[2] == 'ECC15':
-                    slot_id = 115
-                elif sys.argv[2] == 'ECC16':
-                    slot_id = 116
-                elif sys.argv[2] == 'HMAC1':
-                    slot_id = 130
-                elif sys.argv[2] == 'HMAC2':
-                    slot_id = 129
+                slot_id = get_slot_id (sys.argv[2])
             except:
                 print("wipekey [key id] [type]")
                 print("[key id] must be a supported key number")
@@ -885,50 +827,7 @@ def cli():
                 only_key.wipeslot(slot_id)
             elif data[0] == 'setkey' or data[0] == 'genkey':
                 try:
-                    if data[1] == 'RSA1':
-                        slot_id = 1
-                    elif data[1] == 'RSA2':
-                        slot_id = 2
-                    elif data[1] == 'RSA3':
-                        slot_id = 3
-                    elif data[1] == 'RSA4':
-                        slot_id = 4
-                    elif data[1] == 'ECC1':
-                        slot_id = 101
-                    elif data[1] == 'ECC2':
-                        slot_id = 102
-                    elif data[1] == 'ECC3':
-                        slot_id = 103
-                    elif data[1] == 'ECC4':
-                        slot_id = 104
-                    elif data[1] == 'ECC5':
-                        slot_id = 105
-                    elif data[1] == 'ECC6':
-                        slot_id = 106
-                    elif data[1] == 'ECC7':
-                        slot_id = 107
-                    elif data[1] == 'ECC8':
-                        slot_id = 108
-                    elif data[1] == 'ECC9':
-                        slot_id = 109
-                    elif data[1] == 'ECC10':
-                        slot_id = 110
-                    elif data[1] == 'ECC11':
-                        slot_id = 111
-                    elif data[1] == 'ECC12':
-                        slot_id = 112
-                    elif data[1] == 'ECC13':
-                        slot_id = 113
-                    elif data[1] == 'ECC14':
-                        slot_id = 114
-                    elif data[1] == 'ECC15':
-                        slot_id = 115
-                    elif data[1] == 'ECC16':
-                        slot_id = 116
-                    elif data[1] == 'HMAC1':
-                        slot_id = 130
-                    elif data[1] == 'HMAC2':
-                        slot_id = 129
+                    slot_id = get_slot_id (data[1])
                 except:
                     print("setkey [key id] [type] [features]")
                     print("[key id] must be a supported key number")
@@ -954,50 +853,7 @@ def cli():
                     continue
             elif data[0] == 'wipekey':
                 try:
-                    if data[1] == 'RSA1':
-                        slot_id = 1
-                    elif data[1] == 'RSA2':
-                        slot_id = 2
-                    elif data[1] == 'RSA3':
-                        slot_id = 3
-                    elif data[1] == 'RSA4':
-                        slot_id = 4
-                    elif data[1] == 'ECC1':
-                        slot_id = 101
-                    elif data[1] == 'ECC2':
-                        slot_id = 102
-                    elif data[1] == 'ECC3':
-                        slot_id = 103
-                    elif data[1] == 'ECC4':
-                        slot_id = 104
-                    elif data[1] == 'ECC5':
-                        slot_id = 105
-                    elif data[1] == 'ECC6':
-                        slot_id = 106
-                    elif data[1] == 'ECC7':
-                        slot_id = 107
-                    elif data[1] == 'ECC8':
-                        slot_id = 108
-                    elif data[1] == 'ECC9':
-                        slot_id = 109
-                    elif data[1] == 'ECC10':
-                        slot_id = 110
-                    elif data[1] == 'ECC11':
-                        slot_id = 111
-                    elif data[1] == 'ECC12':
-                        slot_id = 112
-                    elif data[1] == 'ECC13':
-                        slot_id = 113
-                    elif data[1] == 'ECC14':
-                        slot_id = 114
-                    elif data[1] == 'ECC15':
-                        slot_id = 115
-                    elif data[1] == 'ECC16':
-                        slot_id = 116
-                    elif data[1] == 'HMAC1':
-                        slot_id = 130
-                    elif data[1] == 'HMAC2':
-                        slot_id = 129
+                    slot_id = get_slot_id (data[1])
                 except:
                     print("wipekey [key id] [type]")
                     print("[key id] must be a supported key number")


### PR DESCRIPTION
This pull request enable setting resetting the backup passphrase key containing the sha256sum of the passphrase.
This is done by adding the BACKUP name in the code like RSA1 to RSA2 and ECC1 to ECC16.

Then it is possible to set the passphrase with:

```shell
read -s -p "Enter Passphrase:" PASSPHRASE1
echo
read -s -p "Retype passphrase:" PASSPHRASE2
echo
if [ "$PASSPHRASE1" != "$PASSPHRASE2" ]
then
echo "Error passphrases mismatch" > /dev/stderr
else
onlykey-cli setkey BACKUP x b $(printf "%s" "$PASSPHRASE1" | sha256sum | grep -o '[0-9a-fA-F]*')
fi
PASSPHRASE1=""
PASSPHRASE2=""
```

And wipe it with:

```shell
onlykey-cli wipekey BACKUP
```