### PR TITLE
feat: Add canonical PQ helpers module (onlykey.pq)

### DIFF
--- a/onlykey/pq.py
+++ b/onlykey/pq.py
@@ -1,0 +1,211 @@
+"""Post-quantum cryptographic helpers for OnlyKey.
+
+Canonical location for X-Wing (ML-KEM-768 + X25519) helper types and
+utilities used by downstream projects (lib-agent, onlykey-a2a-bridge,
+onlykey-agent-skills).
+
+The low-level HID transport lives in onlykey.age_plugin.onlykey_hid.OnlyKeyPQ.
+The host-side X-Wing encapsulation lives in onlykey.age_plugin.xwing.
+This module provides the higher-level helpers that sit on top of both.
+
+Usage::
+
+    from onlykey.pq import (
+        xwing_fingerprint,
+        xwing_encaps,
+        derive_session_key,
+        PQPublicInfo,
+    )
+
+    # Fingerprint a public key (8-byte SHA-256 prefix)
+    fp = xwing_fingerprint(pk)
+
+    # Encapsulate a shared secret (host-side, no device needed)
+    ss, ct = xwing_encaps(recipient_pk)
+
+    # Derive a session key from a shared secret
+    key = derive_session_key(ss, context=b"my-app-v1")
+
+    # Serialize public key info for wire/storage
+    info = PQPublicInfo.from_raw(pk)
+    d = info.to_dict()
+    info2 = PQPublicInfo.from_dict(d)
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Tuple
+
+# Re-export constants from the HID module
+from onlykey.age_plugin.onlykey_hid import (
+    XWING_PK_SIZE,
+    XWING_CT_SIZE,
+    XWING_SS_SIZE,
+)
+
+__all__ = [
+    "XWING_PK_SIZE",
+    "XWING_CT_SIZE",
+    "XWING_SS_SIZE",
+    "XWING_FINGERPRINT_LEN",
+    "xwing_fingerprint",
+    "xwing_encaps",
+    "derive_session_key",
+    "PQPublicInfo",
+]
+
+# Fingerprint: first 8 bytes of SHA-256(public_key)
+XWING_FINGERPRINT_LEN = 8
+
+
+def xwing_fingerprint(pk: bytes) -> bytes:
+    """Compute a short fingerprint of an X-Wing public key.
+
+    Used for identity binding — the fingerprint can be embedded in
+    age identity strings or Agent Card extensions to verify that the
+    correct device is being used.
+
+    Args:
+        pk: 1216-byte X-Wing public key.
+
+    Returns:
+        8-byte SHA-256 fingerprint.
+    """
+    if len(pk) != XWING_PK_SIZE:
+        raise ValueError(
+            f"X-Wing public key must be {XWING_PK_SIZE} bytes, got {len(pk)}"
+        )
+    return hashlib.sha256(pk).digest()[:XWING_FINGERPRINT_LEN]
+
+
+def xwing_encaps(recipient_pk: bytes) -> Tuple[bytes, bytes]:
+    """Encapsulate a shared secret against an X-Wing public key.
+
+    Host-side operation — no OnlyKey device needed. Generates a random
+    ephemeral key and computes the X-Wing KEM encapsulation.
+
+    This is a convenience wrapper around
+    ``onlykey.age_plugin.xwing.xwing_encaps_host``.
+
+    Args:
+        recipient_pk: 1216-byte X-Wing public key.
+
+    Returns:
+        Tuple of (shared_secret, ciphertext):
+          - shared_secret: 32-byte shared secret
+          - ciphertext: 1120-byte X-Wing ciphertext to send to recipient
+    """
+    if len(recipient_pk) != XWING_PK_SIZE:
+        raise ValueError(
+            f"Recipient public key must be {XWING_PK_SIZE} bytes, "
+            f"got {len(recipient_pk)}"
+        )
+    from onlykey.age_plugin.xwing import xwing_encaps_host
+    return xwing_encaps_host(recipient_pk)
+
+
+def derive_session_key(
+    shared_secret: bytes,
+    context: bytes = b"onlykey-pq-v1",
+    key_len: int = 32,
+) -> bytes:
+    """Derive a session key from an X-Wing shared secret using HKDF-SHA256.
+
+    For non-age use cases (A2A channels, MCP tool encryption, etc.) where
+    callers need a session key rather than an age file key.
+
+    Args:
+        shared_secret: 32-byte X-Wing shared secret from encaps/decaps.
+        context: Application context bytes for domain separation.
+            Different applications MUST use different context strings.
+        key_len: Desired output key length (default 32).
+
+    Returns:
+        Derived key bytes.
+    """
+    if len(shared_secret) != XWING_SS_SIZE:
+        raise ValueError(
+            f"Shared secret must be {XWING_SS_SIZE} bytes, "
+            f"got {len(shared_secret)}"
+        )
+
+    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+    from cryptography.hazmat.primitives import hashes
+
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=key_len,
+        salt=None,
+        info=context,
+    )
+    return hkdf.derive(shared_secret)
+
+
+@dataclass(frozen=True)
+class PQPublicInfo:
+    """Serializable container for an X-Wing public key and its fingerprint.
+
+    Used when exchanging PQ key material between agents (Agent Cards,
+    MCP tool configuration, etc.).
+
+    Attributes:
+        public_key: 1216-byte X-Wing public key.
+        fingerprint: 8-byte SHA-256 fingerprint.
+    """
+
+    public_key: bytes
+    fingerprint: bytes
+
+    def __post_init__(self) -> None:
+        if len(self.public_key) != XWING_PK_SIZE:
+            raise ValueError(
+                f"X-Wing public key must be {XWING_PK_SIZE} bytes, "
+                f"got {len(self.public_key)}"
+            )
+        if len(self.fingerprint) != XWING_FINGERPRINT_LEN:
+            raise ValueError(
+                f"Fingerprint must be {XWING_FINGERPRINT_LEN} bytes, "
+                f"got {len(self.fingerprint)}"
+            )
+
+    @classmethod
+    def from_raw(cls, pk: bytes) -> PQPublicInfo:
+        """Create from a raw public key, computing the fingerprint."""
+        return cls(public_key=pk, fingerprint=xwing_fingerprint(pk))
+
+    @classmethod
+    def from_device(cls, device) -> PQPublicInfo:
+        """Read PQ public info from a connected OnlyKey device.
+
+        Works with any object that has an ``xwing_getpubkey()`` method:
+          - ``onlykey.age_plugin.onlykey_hid.OnlyKeyPQ``
+          - ``libagent.age.client.Client``
+          - ``onlykey_a2a.crypto.device.OnlyKeyDevice``
+
+        Args:
+            device: Object with ``xwing_getpubkey() -> bytes`` method.
+        """
+        pk = device.xwing_getpubkey()
+        return cls.from_raw(pk)
+
+    def verify_fingerprint(self) -> bool:
+        """Check that the fingerprint matches the public key."""
+        return self.fingerprint == xwing_fingerprint(self.public_key)
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize for JSON/Agent Card/wire format."""
+        return {
+            "algorithm": "X-Wing",
+            "kem": "mlkem768x25519",
+            "public_key_hex": self.public_key.hex(),
+            "fingerprint_hex": self.fingerprint.hex(),
+            "pk_size": str(XWING_PK_SIZE),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, str]) -> PQPublicInfo:
+        """Deserialize from JSON/Agent Card/wire format."""
+        pk = bytes.fromhex(data["public_key_hex"])
+        fp = bytes.fromhex(data["fingerprint_hex"])
+        return cls(public_key=pk, fingerprint=fp)

--- a/tests/test_pq.py
+++ b/tests/test_pq.py
@@ -1,0 +1,125 @@
+"""Tests for onlykey.pq — the canonical PQ helpers in python-onlykey.
+
+Tests fingerprint computation, PQPublicInfo serialization, and
+session key derivation. Does NOT require hardware — uses mock data.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+
+import pytest
+
+from onlykey.pq import (
+    XWING_PK_SIZE,
+    XWING_CT_SIZE,
+    XWING_SS_SIZE,
+    XWING_FINGERPRINT_LEN,
+    xwing_fingerprint,
+    derive_session_key,
+    PQPublicInfo,
+)
+
+
+class TestXwingFingerprint:
+    def test_correct_length(self):
+        pk = os.urandom(XWING_PK_SIZE)
+        fp = xwing_fingerprint(pk)
+        assert len(fp) == XWING_FINGERPRINT_LEN
+
+    def test_deterministic(self):
+        pk = os.urandom(XWING_PK_SIZE)
+        assert xwing_fingerprint(pk) == xwing_fingerprint(pk)
+
+    def test_matches_sha256_prefix(self):
+        pk = os.urandom(XWING_PK_SIZE)
+        expected = hashlib.sha256(pk).digest()[:XWING_FINGERPRINT_LEN]
+        assert xwing_fingerprint(pk) == expected
+
+    def test_different_keys_different_fingerprints(self):
+        pk1 = os.urandom(XWING_PK_SIZE)
+        pk2 = os.urandom(XWING_PK_SIZE)
+        assert xwing_fingerprint(pk1) != xwing_fingerprint(pk2)
+
+    def test_wrong_size_raises(self):
+        with pytest.raises(ValueError, match=str(XWING_PK_SIZE)):
+            xwing_fingerprint(os.urandom(100))
+
+
+class TestDeriveSessionKey:
+    def test_correct_length(self):
+        ss = os.urandom(XWING_SS_SIZE)
+        key = derive_session_key(ss)
+        assert len(key) == 32
+
+    def test_custom_length(self):
+        ss = os.urandom(XWING_SS_SIZE)
+        key = derive_session_key(ss, key_len=64)
+        assert len(key) == 64
+
+    def test_deterministic(self):
+        ss = os.urandom(XWING_SS_SIZE)
+        k1 = derive_session_key(ss, context=b"test")
+        k2 = derive_session_key(ss, context=b"test")
+        assert k1 == k2
+
+    def test_different_contexts(self):
+        ss = os.urandom(XWING_SS_SIZE)
+        k1 = derive_session_key(ss, context=b"context-a")
+        k2 = derive_session_key(ss, context=b"context-b")
+        assert k1 != k2
+
+    def test_different_secrets(self):
+        ss1 = os.urandom(XWING_SS_SIZE)
+        ss2 = os.urandom(XWING_SS_SIZE)
+        k1 = derive_session_key(ss1, context=b"test")
+        k2 = derive_session_key(ss2, context=b"test")
+        assert k1 != k2
+
+    def test_wrong_ss_size_raises(self):
+        with pytest.raises(ValueError, match=str(XWING_SS_SIZE)):
+            derive_session_key(os.urandom(16))
+
+
+class TestPQPublicInfo:
+    def test_from_raw(self):
+        pk = os.urandom(XWING_PK_SIZE)
+        info = PQPublicInfo.from_raw(pk)
+        assert info.public_key == pk
+        assert len(info.fingerprint) == XWING_FINGERPRINT_LEN
+
+    def test_verify_fingerprint(self):
+        pk = os.urandom(XWING_PK_SIZE)
+        info = PQPublicInfo.from_raw(pk)
+        assert info.verify_fingerprint() is True
+
+    def test_tampered_fingerprint(self):
+        pk = os.urandom(XWING_PK_SIZE)
+        bad = PQPublicInfo(public_key=pk, fingerprint=b"\xff" * XWING_FINGERPRINT_LEN)
+        assert bad.verify_fingerprint() is False
+
+    def test_wrong_pk_size(self):
+        with pytest.raises(ValueError):
+            PQPublicInfo(public_key=b"\x00" * 100, fingerprint=b"\x00" * XWING_FINGERPRINT_LEN)
+
+    def test_wrong_fp_size(self):
+        with pytest.raises(ValueError):
+            PQPublicInfo(public_key=os.urandom(XWING_PK_SIZE), fingerprint=b"\x00" * 4)
+
+    def test_round_trip_dict(self):
+        pk = os.urandom(XWING_PK_SIZE)
+        info = PQPublicInfo.from_raw(pk)
+        d = info.to_dict()
+        info2 = PQPublicInfo.from_dict(d)
+        assert info.public_key == info2.public_key
+        assert info.fingerprint == info2.fingerprint
+
+    def test_dict_fields(self):
+        pk = os.urandom(XWING_PK_SIZE)
+        info = PQPublicInfo.from_raw(pk)
+        d = info.to_dict()
+        assert d["algorithm"] == "X-Wing"
+        assert d["kem"] == "mlkem768x25519"
+        assert d["pk_size"] == str(XWING_PK_SIZE)
+        assert "public_key_hex" in d
+        assert "fingerprint_hex" in d


### PR DESCRIPTION
## Summary

Adds `onlykey/pq.py` — the canonical source of truth for X-Wing (ML-KEM-768 + X25519) helpers used by downstream projects (lib-agent, onlykey-a2a-bridge, onlykey-agent-skills).

### New APIs
- `xwing_fingerprint(pk)` — 8-byte SHA-256 identity fingerprint
- - `xwing_encaps(recipient_pk)` — host-side encapsulation wrapper (delegates to `xwing.xwing_encaps_host`)
- - `derive_session_key(ss, context, key_len)` — HKDF-SHA256 for non-age use cases (A2A, MCP)
- - `PQPublicInfo` dataclass — serializable public key + fingerprint with `to_dict`/`from_dict` for wire format
### Design
- Re-exports `XWING_PK_SIZE`, `XWING_CT_SIZE`, `XWING_SS_SIZE` from the HID module
- - Lazy imports for `cryptography` (HKDF) and `xwing` to keep the module lightweight
- - `PQPublicInfo.from_device()` works with any object that has `xwing_getpubkey()` (OnlyKeyPQ, Client, OnlyKeyDevice)
### Tests
- `tests/test_pq.py` — comprehensive tests for fingerprint, session key derivation, and PQPublicInfo round-trip (no hardware required)